### PR TITLE
Task list

### DIFF
--- a/lib/screens/todo_home.dart
+++ b/lib/screens/todo_home.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/task.dart';
+import '../widgets/task_list.dart';
 import '../widgets/add_task_field.dart';
-import '../widgets/task_list.dart'; // Import TaskTile
-
 
 class TodoHome extends StatefulWidget {
   @override
@@ -36,24 +35,59 @@ class _TodoHomeState extends State<TodoHome> {
 
   @override
   Widget build(BuildContext context) {
+    // Separate tasks into finished and unfinished
+    List<Task> finishedTasks = [];
+    List<Task> unfinishedTasks = [];
+
+    for (var task in _tasks) {
+      if (task.isCompleted) {
+        finishedTasks.add(task);
+      } else {
+        unfinishedTasks.add(task);
+      }
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text('To-Do List'),
       ),
       body: Column(
         children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: AddTaskField(
-              taskController: _taskController,
-              onAddTask: _addTask,
-            ),
-          ),
           Expanded(
-            child: TaskList(
-              tasks: _tasks,
-              onToggleComplete: _toggleComplete,
-              onDelete: _deleteTask,
+            child: ListView(
+              children: <Widget>[
+                // Display unfinished tasks first
+                if (unfinishedTasks.isNotEmpty)
+                  ExpansionTile(
+                    title: Text('${unfinishedTasks.length} Tasks left'),
+                    initiallyExpanded: true, 
+                    children: [
+                      TaskList(
+                      tasks: unfinishedTasks,
+                      onToggleComplete: _toggleComplete,
+                      onDelete: _deleteTask,
+                  ),
+                    ],
+                    ),
+                // Add Task Input Field after unfinished tasks
+                AddTaskField(
+                  taskController: _taskController,
+                  onAddTask: _addTask,
+                ),
+                // Display finished tasks
+                if (finishedTasks.isNotEmpty)
+                  ExpansionTile(
+                    title: Text('${finishedTasks.length} Completed tasks'),
+                    initiallyExpanded: true, 
+                    children: [
+                      TaskList(
+                        tasks: finishedTasks,
+                        onToggleComplete: _toggleComplete,
+                        onDelete: _deleteTask,
+                      ),
+                    ],
+                  ),
+              ],
             ),
           ),
         ],

--- a/lib/screens/todo_home.dart
+++ b/lib/screens/todo_home.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import '../models/task.dart';
 import '../widgets/add_task_field.dart';
-import '../widgets/task_tile.dart'; // Import TaskTile
+import '../widgets/task_list.dart'; // Import TaskTile
+
 
 class TodoHome extends StatefulWidget {
   @override
@@ -49,16 +50,10 @@ class _TodoHomeState extends State<TodoHome> {
             ),
           ),
           Expanded(
-            child: ListView.builder(
-              itemCount: _tasks.length,
-              itemBuilder: (context, index) {
-                final task = _tasks[index];
-                return TaskTile(
-                  task: task,
-                  onToggleComplete: _toggleComplete,
-                  onDelete: _deleteTask,
-                );
-              },
+            child: TaskList(
+              tasks: _tasks,
+              onToggleComplete: _toggleComplete,
+              onDelete: _deleteTask,
             ),
           ),
         ],

--- a/lib/widgets/task_list.dart
+++ b/lib/widgets/task_list.dart
@@ -16,6 +16,8 @@ class TaskList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
+      physics: NeverScrollableScrollPhysics(),
+      shrinkWrap: true,
       itemCount: tasks.length,
       itemBuilder: (context, index) {
         final task = tasks[index];

--- a/lib/widgets/task_list.dart
+++ b/lib/widgets/task_list.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+import 'task_tile.dart';
+
+class TaskList extends StatelessWidget {
+  final List<Task> tasks;
+  final Function(String) onToggleComplete;
+  final Function(String) onDelete;
+
+  const TaskList({
+    required this.tasks,
+    required this.onToggleComplete,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: tasks.length,
+      itemBuilder: (context, index) {
+        final task = tasks[index];
+        return TaskTile(
+          task: task,
+          onToggleComplete: onToggleComplete,
+          onDelete: onDelete,
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Pull Request: Separate Tasks into Finished and Unfinished Categories

### Changes:
- Added logic to separate tasks into unfinished and finished status in `TodoHome`.
- Integrated `TaskList` widget to display both unfinished and completed tasks.
- Added `ExpansionTile` for finished tasks with `initiallyExpanded` set to true for default open state.
- The `AddTaskField` appears at the end of the unfinished tasks for easy task entry.

